### PR TITLE
Remove solus-project references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 libosdev
 --------
 
-[![Report](https://goreportcard.com/badge/github.com/solus-project/libosdev)](https://goreportcard.com/report/github.com/solus-project/libosdev) [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) [![GoDoc](https://godoc.org/github.com/solus-project/libosdev?status.svg)](https://godoc.org/github.com/solus-project/libosdev)
+[![Report](https://goreportcard.com/badge/github.com/getsolus/libosdev)](https://goreportcard.com/report/github.com/getsolus/libosdev) [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) [![GoDoc](https://godoc.org/github.com/getsolus/libosdev?status.svg)](https://godoc.org/github.com/getsolus/libosdev)
 
-Helper library for Solus tooling, such as [USpin](https://github.com/solus-project/USpin) and soon `solbuild`.
+Helper library for Solus tooling.
 
 libosdev is a [Solus project](https://getsol.us/).
 
@@ -12,6 +12,6 @@ libosdev is a [Solus project](https://getsol.us/).
 License
 -------
 
-Copyright © 2016 Solus Project
+Copyright © 2016-2022 Solus Project
 
 `libosdev` is available under the terms of the Apache-2.0 license

--- a/commands/main.go
+++ b/commands/main.go
@@ -1,5 +1,6 @@
 //
 // Copyright © 2016 Ikey Doherty <ikey@solus-project.com>
+// Copyright © 2018-2022 Solus Project <copyright@getsol.us>
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/disk/create.go
+++ b/disk/create.go
@@ -1,5 +1,6 @@
 //
 // Copyright © 2016 Ikey Doherty <ikey@solus-project.com>
+// Copyright © 2018-2022 Solus Project <copyright@getsol.us>
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,10 +19,11 @@ package disk
 
 import (
 	"fmt"
-	"github.com/solus-project/libosdev/commands"
 	"os"
 	"path/filepath"
 	"syscall"
+
+	"github.com/getsolus/libosdev/commands"
 )
 
 // CreateSparseFile will create a new sparse file with the given filename and

--- a/disk/devices.go
+++ b/disk/devices.go
@@ -1,5 +1,6 @@
 //
 // Copyright © 2016 Ikey Doherty <ikey@solus-project.com>
+// Copyright © 2018-2022 Solus Project <copyright@getsol.us>
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,8 +19,9 @@ package disk
 
 import (
 	"fmt"
-	"github.com/solus-project/libosdev/commands"
 	"path/filepath"
+
+	"github.com/getsolus/libosdev/commands"
 )
 
 // DeviceNode represents a /dev/ node to be created in chroots

--- a/disk/filesystem.go
+++ b/disk/filesystem.go
@@ -1,5 +1,6 @@
 //
 // Copyright © 2016 Ikey Doherty <ikey@solus-project.com>
+// Copyright © 2018-2022 Solus Project <copyright@getsol.us>
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,7 +19,8 @@ package disk
 
 import (
 	"fmt"
-	"github.com/solus-project/libosdev/commands"
+
+	"github.com/getsolus/libosdev/commands"
 )
 
 // FilesystemFormatFunc is the prototype for functions that format filesystems

--- a/disk/main.go
+++ b/disk/main.go
@@ -1,5 +1,6 @@
 //
 // Copyright © 2016 Ikey Doherty <ikey@solus-project.com>
+// Copyright © 2018-2022 Solus Project <copyright@getsol.us>
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/disk/mount.go
+++ b/disk/mount.go
@@ -1,5 +1,6 @@
 //
 // Copyright © 2016 Ikey Doherty <ikey@solus-project.com>
+// Copyright © 2018-2022 Solus Project <copyright@getsol.us>
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,12 +19,13 @@ package disk
 
 import (
 	"fmt"
-	"github.com/solus-project/libosdev/commands"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/getsolus/libosdev/commands"
 )
 
 // LenSort is to enable reverse length sorting

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/getsolus/libosdev
+
+go 1.17

--- a/pkg/doc.go
+++ b/pkg/doc.go
@@ -1,5 +1,6 @@
 //
 // Copyright © 2016 Ikey Doherty <ikey@solus-project.com>
+// Copyright © 2018-2022 Solus Project <copyright@getsol.us>
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/eopkg.go
+++ b/pkg/eopkg.go
@@ -1,5 +1,6 @@
 //
 // Copyright © 2016 Ikey Doherty <ikey@solus-project.com>
+// Copyright © 2018-2022 Solus Project <copyright@getsol.us>
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,13 +18,14 @@
 package pkg
 
 import (
-	"github.com/solus-project/libosdev/commands"
-	"github.com/solus-project/libosdev/disk"
 	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/getsolus/libosdev/commands"
+	"github.com/getsolus/libosdev/disk"
 )
 
 const (

--- a/pkg/main.go
+++ b/pkg/main.go
@@ -1,5 +1,6 @@
 //
 // Copyright © 2016 Ikey Doherty <ikey@solus-project.com>
+// Copyright © 2018-2022 Solus Project <copyright@getsol.us>
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/manager.go
+++ b/pkg/manager.go
@@ -1,5 +1,6 @@
 //
 // Copyright © 2016 Ikey Doherty <ikey@solus-project.com>
+// Copyright © 2018-2022 Solus Project <copyright@getsol.us>
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
There is still a lot of work to do to this library, e.g. a proper refactoring, but for starters let's bring libosdev to 2022 by updating the copyright notice, removing old solus-project organization references and adding a go.mod file.

This in turn will allow libosdev users, like solbuild, to remove solus-project organization references.

I volunteer to improve this library with suggestions or personal initiatives.